### PR TITLE
chore: rename project from frad-in to bellab.re

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🐾 frad-in — Personal Playground of Thomas Fradin de Bellabre
+# 🐾 bellab.re — Personal Playground of Thomas Fradin de Bellabre
 
 > A modern, modular, and playful dev space to showcase my experiments, side projects, and tech oddities.  
 > Live at [https://bellab.re](https://bellab.re)
@@ -11,7 +11,7 @@
 
 ---
 
-## 🚀 What is `frad-in`?
+## 🚀 What is `bellab.re`?
 
 This is my digital garage.  
 A personal playground where I publish weird, smart, and fun stuff I build with modern web tools. Hosted on [bellab.re](https://bellab.re), this space is intentionally:
@@ -67,7 +67,7 @@ A personal playground where I publish weird, smart, and fun stuff I build with m
 Clone this repo and start developing:
 
 ```bash
-git clone https://github.com/Zakran27/frad-in.git
-cd frad-in
+git clone https://github.com/Zakran27/bellab.re.git
+cd bellab.re
 npm install
 npm run dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "frad-in",
+  "name": "bellab.re",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frad-in",
+      "name": "bellab.re",
       "version": "0.1.0",
       "dependencies": {
         "@react-google-maps/api": "^2.20.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frad-in",
+  "name": "bellab.re",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
The site has been live at bellab.re for a while — aligning the repo and package name with the actual URL so everything matches. Sets the stage for the upcoming Supabase → Neon migration on the same branch series.

Note: GitHub repo already renamed (`frad-in` → `bellab.re`) and local `origin` remote updated. Local folder rename (`C:\Users\tfb27\Documents\web\frad-in` → `bellab.re`) still needs to happen manually after this PR merges.